### PR TITLE
Allow null as a return type in the request

### DIFF
--- a/protocol.foldingProvider.md
+++ b/protocol.foldingProvider.md
@@ -74,7 +74,7 @@ export interface FoldingRangeRequestParam {
 ```
 
 _Response_:
-* result: `FoldingRange[]` defined as follows:
+* result: `FoldingRange[] | null` defined as follows:
 ```ts
 
 /**


### PR DESCRIPTION
textDocument requests in the language server protocol such as `textDocument/signatureHelp`, `textDocument/completion`, `textDocument/definition`, and so on all allow `null` as a result so it should be allowed for `textDocument/foldingRanges` also.