### PR TITLE
FoldingRangeServerCapabilities' foldingRangeProvider should accept boolean

### DIFF
--- a/protocol.foldingProvider.md
+++ b/protocol.foldingProvider.md
@@ -15,7 +15,7 @@ export interface FoldingRangeServerCapabilities {
 	/**
 	 * The server provides folding provider support.
 	 */
-	foldingRangeProvider?: FoldingRangeProviderOptions | (FoldingRangeProviderOptions & TextDocumentRegistrationOptions & StaticRegistrationOptions);
+	foldingRangeProvider?: boolean | FoldingRangeProviderOptions | (FoldingRangeProviderOptions & TextDocumentRegistrationOptions & StaticRegistrationOptions);
 }
 
 export interface FoldingRangeProviderOptions {

--- a/src/protocol.foldingProvider.ts
+++ b/src/protocol.foldingProvider.ts
@@ -44,7 +44,7 @@ export interface FoldingRangeServerCapabilities {
 	/**
 	 * The server provides folding provider support.
 	 */
-	foldingRangeProvider?: FoldingRangeProviderOptions | (FoldingRangeProviderOptions & TextDocumentRegistrationOptions & StaticRegistrationOptions);
+	foldingRangeProvider?: boolean | FoldingRangeProviderOptions | (FoldingRangeProviderOptions & TextDocumentRegistrationOptions & StaticRegistrationOptions);
 }
 
 /**


### PR DESCRIPTION
We should be consistent with the other providers of a server's capability and accept `boolean` values for `foldingRangeProvider`. This is basically the same issue that was reported in Microsoft/vscode-languageserver-node#349.